### PR TITLE
RememBear MacOS: Customized Installation Process

### DIFF
--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -31,6 +31,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject
 @property (copy, readonly) NSString *displayVersionString;
 @property (copy, readonly) NSDictionary *deltaUpdates;
 @property (strong, readonly) NSURL *infoURL;
+@property (strong) NSString *localInstallationPath;
 
 // Initializes with data from a dictionary provided by the RSS class.
 - (instancetype)initWithDictionary:(NSDictionary *)dict;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -371,6 +371,8 @@
         NSError *reason = [NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{NSLocalizedDescriptionKey: @"Failed to extract update."}];
         [self unarchiverDidFailWithError:reason];
     } else {
+        self.updateItem.localInstallationPath = self.downloadPath.stringByDeletingLastPathComponent;
+      
         [unarchiver unarchiveWithCompletionBlock:^(NSError *err){
             if (err) {
                 [self unarchiverDidFailWithError:err];
@@ -493,101 +495,104 @@
         }
     }
 
-
+    BOOL continueInstall = TRUE;
     if ([updaterDelegate respondsToSelector:@selector(updater:willInstallUpdate:)]) {
-        [updaterDelegate updater:self.updater willInstallUpdate:self.updateItem];
+        continueInstall = [updaterDelegate updater:self.updater willInstallUpdate:self.updateItem];
     }
 
-    NSBundle *sparkleBundle = updater.sparkleBundle;
-    if (!sparkleBundle) {
-        SULog(SULogLevelError, @"Sparkle bundle is gone?");
-        return;
-    }
-
-    // Copy the relauncher into a temporary directory so we can get to it after the new version's installed.
-    // Only the paranoid survive: if there's already a stray copy of relaunch there, we would have problems.
-    NSString *const relaunchToolSourceName = @"" SPARKLE_RELAUNCH_TOOL_NAME;
-    NSString *const relaunchToolSourcePath = [sparkleBundle pathForResource:relaunchToolSourceName ofType:@"app"];
-    NSString *relaunchCopyTargetPath = nil;
-    NSError *error = nil;
-    BOOL copiedRelaunchPath = NO;
-
-    if (!relaunchToolSourceName || ![relaunchToolSourceName length]) {
-        SULog(SULogLevelError, @"SPARKLE_RELAUNCH_TOOL_NAME not configued");
-    }
-
-    if (!relaunchToolSourcePath) {
-        SULog(SULogLevelError, @"Sparkle.framework is damaged. %@ is missing", relaunchToolSourceName);
-    }
-
-    if (relaunchToolSourcePath) {
-        NSString *hostBundleBaseName = [[self.host.bundlePath lastPathComponent] stringByDeletingPathExtension];
-        if (!hostBundleBaseName) {
-            SULog(SULogLevelError, @"Unable to get bundlePath");
-            hostBundleBaseName = @"Sparkle";
-        }
-        NSString *relaunchCopyBaseName = [NSString stringWithFormat:@"%@ (Autoupdate).app", hostBundleBaseName];
-
-        relaunchCopyTargetPath = [[self appCachePath] stringByAppendingPathComponent:relaunchCopyBaseName];
-
-        SUFileManager *fileManager = [SUFileManager defaultManager];
-
-        NSURL *relaunchToolSourceURL = [NSURL fileURLWithPath:relaunchToolSourcePath];
-        NSURL *relaunchCopyTargetURL = [NSURL fileURLWithPath:relaunchCopyTargetPath];
-
-        // We only need to run our copy of the app by spawning a task
-        // Since we are copying the app to a directory that is write-accessible, we don't need to muck with owner/group IDs
-        if ([self preparePathForRelaunchTool:relaunchCopyTargetPath error:&error] && [fileManager copyItemAtURL:relaunchToolSourceURL toURL:relaunchCopyTargetURL error:&error]) {
-            copiedRelaunchPath = YES;
-
-            // We probably don't need to release the quarantine, but we'll do it just in case it's necessary.
-            // Perhaps in a sandboxed environment this matters more. Note that this may not be a fatal error.
-            NSError *quarantineError = nil;
-            if (![fileManager releaseItemFromQuarantineAtRootURL:relaunchCopyTargetURL error:&quarantineError]) {
-                SULog(SULogLevelError, @"Failed to release quarantine on %@ with error %@", relaunchCopyTargetPath, quarantineError);
-            }
-        }
-    }
-
-    if (!copiedRelaunchPath) {
-        [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURelaunchError userInfo:@{
-            NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@.", nil), [self.host name]],
-            NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"Couldn't copy relauncher (%@) to temporary path (%@)! %@",
-                                                                         relaunchToolSourcePath, relaunchCopyTargetPath, (error ? [error localizedDescription] : @"")],
-        }]];
-        return;
-    }
-
-    self.relaunchPath = relaunchCopyTargetPath; // Set for backwards compatibility, in case any delegates modify it
-    [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdaterWillRestartNotification object:self];
-    if ([updaterDelegate respondsToSelector:@selector(updaterWillRelaunchApplication:)])
-        [updaterDelegate updaterWillRelaunchApplication:self.updater];
-
-    NSString *relaunchToolPath = [[NSBundle bundleWithPath:self.relaunchPath] executablePath];
-    if (!relaunchToolPath || ![[NSFileManager defaultManager] fileExistsAtPath:self.relaunchPath]) {
-        // Note that we explicitly use the host app's name here, since updating plugin for Mail relaunches Mail, not just the plugin.
-        [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURelaunchError userInfo:@{
-            NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@.", nil), [self.host name]],
-            NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"Couldn't find the relauncher (expected to find it at %@ and %@)", relaunchToolSourcePath, self.relaunchPath],
-        }]];
-        return;
-    }
-
-    NSString *pathToRelaunch = [self.host bundlePath];
-    if ([updaterDelegate respondsToSelector:@selector(pathToRelaunchForUpdater:)]) {
-        NSString *delegateRelaunchPath = [updaterDelegate pathToRelaunchForUpdater:self.updater];
-        if (delegateRelaunchPath != nil) {
-            pathToRelaunch = delegateRelaunchPath;
-        }
-    }
+    if (continueInstall) {
     
-    [NSTask launchedTaskWithLaunchPath:relaunchToolPath arguments:@[[self.host bundlePath],
-                                                                    pathToRelaunch,
-                                                                    [NSString stringWithFormat:@"%d", [[NSProcessInfo processInfo] processIdentifier]],
-                                                                    self.tempDir,
-                                                                    relaunch ? @"1" : @"0",
-                                                                    showUI ? @"1" : @"0"]];
-    [self terminateApp];
+      NSBundle *sparkleBundle = updater.sparkleBundle;
+      if (!sparkleBundle) {
+          SULog(SULogLevelError, @"Sparkle bundle is gone?");
+          return;
+      }
+
+      // Copy the relauncher into a temporary directory so we can get to it after the new version's installed.
+      // Only the paranoid survive: if there's already a stray copy of relaunch there, we would have problems.
+      NSString *const relaunchToolSourceName = @"" SPARKLE_RELAUNCH_TOOL_NAME;
+      NSString *const relaunchToolSourcePath = [sparkleBundle pathForResource:relaunchToolSourceName ofType:@"app"];
+      NSString *relaunchCopyTargetPath = nil;
+      NSError *error = nil;
+      BOOL copiedRelaunchPath = NO;
+
+      if (!relaunchToolSourceName || ![relaunchToolSourceName length]) {
+          SULog(SULogLevelError, @"SPARKLE_RELAUNCH_TOOL_NAME not configued");
+      }
+
+      if (!relaunchToolSourcePath) {
+          SULog(SULogLevelError, @"Sparkle.framework is damaged. %@ is missing", relaunchToolSourceName);
+      }
+
+      if (relaunchToolSourcePath) {
+          NSString *hostBundleBaseName = [[self.host.bundlePath lastPathComponent] stringByDeletingPathExtension];
+          if (!hostBundleBaseName) {
+              SULog(SULogLevelError, @"Unable to get bundlePath");
+              hostBundleBaseName = @"Sparkle";
+          }
+          NSString *relaunchCopyBaseName = [NSString stringWithFormat:@"%@ (Autoupdate).app", hostBundleBaseName];
+
+          relaunchCopyTargetPath = [[self appCachePath] stringByAppendingPathComponent:relaunchCopyBaseName];
+
+          SUFileManager *fileManager = [SUFileManager defaultManager];
+
+          NSURL *relaunchToolSourceURL = [NSURL fileURLWithPath:relaunchToolSourcePath];
+          NSURL *relaunchCopyTargetURL = [NSURL fileURLWithPath:relaunchCopyTargetPath];
+
+          // We only need to run our copy of the app by spawning a task
+          // Since we are copying the app to a directory that is write-accessible, we don't need to muck with owner/group IDs
+          if ([self preparePathForRelaunchTool:relaunchCopyTargetPath error:&error] && [fileManager copyItemAtURL:relaunchToolSourceURL toURL:relaunchCopyTargetURL error:&error]) {
+              copiedRelaunchPath = YES;
+
+              // We probably don't need to release the quarantine, but we'll do it just in case it's necessary.
+              // Perhaps in a sandboxed environment this matters more. Note that this may not be a fatal error.
+              NSError *quarantineError = nil;
+              if (![fileManager releaseItemFromQuarantineAtRootURL:relaunchCopyTargetURL error:&quarantineError]) {
+                  SULog(SULogLevelError, @"Failed to release quarantine on %@ with error %@", relaunchCopyTargetPath, quarantineError);
+              }
+          }
+      }
+
+      if (!copiedRelaunchPath) {
+          [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURelaunchError userInfo:@{
+              NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@.", nil), [self.host name]],
+              NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"Couldn't copy relauncher (%@) to temporary path (%@)! %@",
+                                                                           relaunchToolSourcePath, relaunchCopyTargetPath, (error ? [error localizedDescription] : @"")],
+          }]];
+          return;
+      }
+
+      self.relaunchPath = relaunchCopyTargetPath; // Set for backwards compatibility, in case any delegates modify it
+      [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdaterWillRestartNotification object:self];
+      if ([updaterDelegate respondsToSelector:@selector(updaterWillRelaunchApplication:)])
+          [updaterDelegate updaterWillRelaunchApplication:self.updater];
+
+      NSString *relaunchToolPath = [[NSBundle bundleWithPath:self.relaunchPath] executablePath];
+      if (!relaunchToolPath || ![[NSFileManager defaultManager] fileExistsAtPath:self.relaunchPath]) {
+          // Note that we explicitly use the host app's name here, since updating plugin for Mail relaunches Mail, not just the plugin.
+          [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURelaunchError userInfo:@{
+              NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@.", nil), [self.host name]],
+              NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"Couldn't find the relauncher (expected to find it at %@ and %@)", relaunchToolSourcePath, self.relaunchPath],
+          }]];
+          return;
+      }
+
+      NSString *pathToRelaunch = [self.host bundlePath];
+      if ([updaterDelegate respondsToSelector:@selector(pathToRelaunchForUpdater:)]) {
+          NSString *delegateRelaunchPath = [updaterDelegate pathToRelaunchForUpdater:self.updater];
+          if (delegateRelaunchPath != nil) {
+              pathToRelaunch = delegateRelaunchPath;
+          }
+      }
+      
+      [NSTask launchedTaskWithLaunchPath:relaunchToolPath arguments:@[[self.host bundlePath],
+                                                                      pathToRelaunch,
+                                                                      [NSString stringWithFormat:@"%d", [[NSProcessInfo processInfo] processIdentifier]],
+                                                                      self.tempDir,
+                                                                      relaunch ? @"1" : @"0",
+                                                                      showUI ? @"1" : @"0"]];
+      [self terminateApp];
+    }
 }
 
 // Note: this is overridden by the automatic update driver to not terminate in some cases

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -182,7 +182,7 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
  \param updater The SUUpdater instance.
  \param item The appcast item corresponding to the update that is proposed to be installed.
  */
-- (void)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
+- (BOOL)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
 
 /*!
  Returns whether the relaunch should be delayed in order to perform other tasks.

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -181,6 +181,8 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
  
  \param updater The SUUpdater instance.
  \param item The appcast item corresponding to the update that is proposed to be installed.
+ 
+ \return \c NO to prevent any further action. item.localInstallationPath provides the path to the download and extracted archive and any custom actions can be taken at this point.
  */
 - (BOOL)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
 


### PR DESCRIPTION
These changes will let me intercept the expanded installer file and perform my a custom installation action. I've tried to do this with minimal changes to Sparkle, and I will handle more stuff inside the RememBear app.

Basically in the RememBear helper app I will terminate the main app and launch the unarchvived app and installation should proceed correctly.

Sparkle was previously deleting the installer and at the same time launching it. Causing the downloaded app to launch with "missing framework" errors.